### PR TITLE
Bug Details

### DIFF
--- a/ios-test-app/AppDelegate.swift
+++ b/ios-test-app/AppDelegate.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 


### PR DESCRIPTION
When creating a new dev to master.
The auto-labeller and release drafter both get fired. So, they often go into a race condition where labelling is done after release notes generation. This leads to `Dev` PR in release notes.

Fix: use an independent auto-labeller that runs when the pull request is opened/synchronized/etc. Restrict release drafter to pushes on the master branch.

OR

Use separate workflows config for labeller and drafter. See follow-up changes.

Alternate approach could be this: https://github.com/release-drafter/release-drafter/issues/656#issuecomment-806184887